### PR TITLE
Refactor group management in API and GraphQL layers

### DIFF
--- a/DynSec.API/Controllers/DynSec/GroupsController.cs
+++ b/DynSec.API/Controllers/DynSec/GroupsController.cs
@@ -1,6 +1,8 @@
-﻿using DynSec.Model.Commands;
+﻿using DynSec.Model;
+using DynSec.Model.Commands;
 using DynSec.Model.Responses;
 using DynSec.Model.Responses.TopLevel;
+using DynSec.Protocol;
 using DynSec.Protocol.Exceptions;
 using DynSec.Protocol.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -10,12 +12,9 @@ namespace DynSec.API.Controllers.DynSec
 
     [Route("api/[controller]")]
     [ApiController]
-    public class GroupsController : ControllerBase
+    public class GroupsController(IGroupsService _groupService) : ControllerBase
     {
-        private readonly IGroupsService groupService;
-        private readonly IDynamicSecurityRpc dynSec;
-
-        public GroupsController(IGroupsService _groupService, IDynamicSecurityRpc _dynSec) { groupService = _groupService; dynSec = _dynSec; }
+        private readonly IGroupsService groupService = _groupService;
 
         // GET: api/<MQTTdynsecController>/groups
         [HttpGet("groups")]
@@ -75,22 +74,72 @@ namespace DynSec.API.Controllers.DynSec
         [HttpPost("anonymous-group")]
         public async Task<ActionResult<GeneralResponse>> SetAnonymousGroups([FromBody] string group)
         {
-            var cmd = new SetAnonymousGroup(group);
+            try
+            {
+                return Ok(await groupService.SetAnonymous(group));
+            }
+            catch (DynSecProtocolInvalidParameterException e)
+            {
+                return StatusCode(504, e.Message);
+            }
+            catch (DynSecProtocolNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+        }
 
-            var result = await dynSec.ExecuteCommand(cmd) ?? new GeneralResponse
+        // POST: api/<MQTTdynsecController>/group
+        [HttpPost("group")]
+        public async Task<ActionResult<string>> CreateGroup(Group newgroup)
+        {
+            try
             {
-                Error = "Task cancelled",
-                Command = cmd.Command,
-                Data = null
-            };
-            switch (result.Error)
+                return Ok(await groupService.CreateGroup(newgroup));
+            }
+            catch (DynSecProtocolInvalidParameterException e)
             {
-                case "Ok":
-                    return Ok();
-                case "Task cancelled":
-                    return StatusCode(504);
-                default:
-                    return NotFound(result);
+                return StatusCode(504, e.Message);
+            }
+            catch (DynSecProtocolDuplicatedException e)
+            {
+                return StatusCode(409, e.Message);
+            }
+        }
+
+
+        // POST: api/<MQTTdynsecController>/group/modify
+        [HttpPost("group/modify")]
+        public async Task<ActionResult<string>> ModifyGroup(Group group)
+        {
+            try
+            {
+                return Ok(await groupService.ModifyGroup(group));
+            }
+            catch (DynSecProtocolInvalidParameterException e)
+            {
+                return StatusCode(504, e.Message);
+            }
+            catch (DynSecProtocolNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+        }
+
+        // POST: api/<MQTTdynsecController>/group/<group>/delete
+        [HttpPost("group/{group}/delete")]
+        public async Task<ActionResult<string>> DeleteRole(string group)
+        {
+            try
+            {
+                return Ok(await groupService.DeleteGroup(group));
+            }
+            catch (DynSecProtocolInvalidParameterException e)
+            {
+                return StatusCode(504, e.Message);
+            }
+            catch (DynSecProtocolNotFoundException e)
+            {
+                return NotFound(e.Message);
             }
         }
     }

--- a/DynSec.API/Controllers/DynSec/GroupsController.cs
+++ b/DynSec.API/Controllers/DynSec/GroupsController.cs
@@ -127,7 +127,7 @@ namespace DynSec.API.Controllers.DynSec
 
         // POST: api/<MQTTdynsecController>/group/<group>/delete
         [HttpPost("group/{group}/delete")]
-        public async Task<ActionResult<string>> DeleteRole(string group)
+        public async Task<ActionResult<string>> DeleteGroup(string group)
         {
             try
             {

--- a/DynSec.GraphQL/DynSecMutation.cs
+++ b/DynSec.GraphQL/DynSecMutation.cs
@@ -1,6 +1,7 @@
 ﻿using DynSec.Model;
 using DynSec.Model.Responses;
 using DynSec.Protocol.Interfaces;
+using System.Formats.Asn1;
 
 namespace DynSec.GraphQL
 {
@@ -51,6 +52,16 @@ namespace DynSec.GraphQL
         #region ACLs
 
         public async Task<string?> SetDefaultACLsAsync(List<DefaultACL> data) => await aclService.SetDefault(data);
+        #endregion
+
+        #region Groups
+        public async Task<string?> CreateGroupAsync(Group newgroup) => await groupsService.CreateGroup(newgroup);
+        public async Task<string?> ModifyGroupAsync(Group group) => await groupsService.ModifyGroup(group);
+        public async Task<string?> DeleteGroupAsync(string group) => await groupsService.DeleteGroup(group);
+        #endregion
+
+        #region Anonymous Group
+        public async Task<string?> SetAnonymousGroupAsync(string group) => await groupsService.SetAnonymous(group);
         #endregion
     }
 }

--- a/DynSec.GraphQL/DynSecQuery.cs
+++ b/DynSec.GraphQL/DynSecQuery.cs
@@ -42,6 +42,9 @@ namespace DynSec.GraphQL
 
         public async Task<GroupListData?> GetGroupsListAsync(bool? verbose) => await groupsService.GetList(verbose);
         public async Task<GroupInfoData?> GetGroupAsync(string group) => await groupsService.Get(group);
+        #endregion
+
+        #region Anonymous Group
         public async Task<AnonymousGroupInfoData?> GetAnonymousGroupAsync() => await groupsService.GetAnonymous();
         #endregion
 

--- a/DynSec.Protocol/DynamicSecurityRpc.cs
+++ b/DynSec.Protocol/DynamicSecurityRpc.cs
@@ -70,9 +70,10 @@ namespace DynSec.Protocol
             }
             disconnectTimer.Start();
 
+            logger.LogDebug("Command: {command}", commands.AsJSON());
+
             using MqttRpcClient rpcClient = new(client, mqttRpcClientOptions);
             byte[] data = await rpcClient.ExecuteAsync(timeout, "", commands.AsJSON(), MqttQualityOfServiceLevel.AtMostOnce);
-            logger.LogDebug("Command: {command}", commands.AsJSON());
             logger.LogDebug("Response: {response}", System.Text.Encoding.UTF8.GetString(data));
 
             ResponseList response = JsonSerializer.Deserialize<ResponseList>(data, jsonoptions) ?? new();

--- a/DynSec.Protocol/GroupServiceMutations.cs
+++ b/DynSec.Protocol/GroupServiceMutations.cs
@@ -90,6 +90,11 @@ namespace DynSec.Protocol
             return commandDoneString;
         }
 
-
+        public async Task<string?> SetAnonymous(string group)
+        {
+            var cmd = new SetAnonymousGroup(group);
+            var result = await ExecuteCommand<GeneralResponse>(cmd);
+            return commandDoneString;
+        }
     }
 }

--- a/DynSec.Protocol/Interfaces/IGroupsService.cs
+++ b/DynSec.Protocol/Interfaces/IGroupsService.cs
@@ -11,7 +11,7 @@ namespace DynSec.Protocol.Interfaces
         Task<string?> CreateGroup(Group newgroup);
         Task<string?> ModifyGroup(Group newgroup);
         Task<string?> DeleteGroup(string group);
-
+        Task<string?> SetAnonymous(string group);
 
     }
 }


### PR DESCRIPTION
- Updated `GroupsController` to use constructor injection for `IGroupsService`, removing `IDynamicSecurityRpc` and adding new methods for group creation, modification, and deletion with improved error handling.
- Enhanced `DynSecMutation` with new async methods for group management.
- Expanded `DynSecQuery` to include retrieval of anonymous group information.
- Added logging in `DynamicSecurityRpc` for better command traceability.
- Introduced a new method in `GroupServiceMutations` for setting anonymous groups.
- Updated `IGroupsService` interface to include new group management methods.